### PR TITLE
fix(publish): use npm publish instead of yarn publish

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -58,4 +58,4 @@ else
 fi
 
 # Publish with the appropriate tag
-yarn publish --tag "$TAG"
+npm publish --tag "$TAG"


### PR DESCRIPTION
## Summary

- `yarn publish` routes to `registry.yarnpkg.com`, which doesn't receive the auth token configured for `registry.npmjs.org`
- This caused the v0.16.0 publish to fail with `"https://registry.yarnpkg.com/datagrid-ai: Not found"`
- Switching to `npm publish` ensures the token set via `npm config set //registry.npmjs.org/:_authToken` is used correctly

## Root cause

The newer pinned `actions/setup-node` SHA writes a host-scoped `.npmrc` entry (`//registry.npmjs.org/:_authToken`) that `yarn publish` doesn't pick up when routing through `registry.yarnpkg.com`. The v0.9.0 publish worked by accident because `setup-node@v3` wrote auth in a format Yarn could read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in the release script only; no runtime app or auth logic changes beyond fixing how packages are uploaded.
> 
> **Overview**
> Fixes failed npm releases by changing the publish step in `bin/publish-npm` from **`yarn publish`** to **`npm publish`** (still using the same dist-tag logic for prereleases vs `latest`).
> 
> **Yarn** was hitting `registry.yarnpkg.com` and not using the host-scoped `//registry.npmjs.org/:_authToken` from CI/`setup-node`, which led to 404-style publish failures; **npm publish** uses the configured npm registry and token as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d7e5ccd0fb202bfd4d42e7d5699b622f27cf11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->