### PR TITLE
fix(ci): publish npm package as public without token env

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -54,7 +54,5 @@ jobs:
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - run: npm publish --provenance --tag ${{ steps.tag.outputs.tag }}
+      - run: npm publish --provenance --access public --tag ${{ steps.tag.outputs.tag }}
         working-directory: dist
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Switch publish step to explicit public access and remove NODE_AUTH_TOKEN env from workflow to align with current npm publish flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publishing is a release-critical path; removing the token env assumes OIDC or another auth path still works, and a misconfigured publish could fail releases or affect package visibility.
> 
> **Overview**
> Updates the **Publish to npm** workflow so `npm publish` runs with **`--access public`**, ensuring scoped packages are published as publicly installable without relying on a separate access flag in npm config.
> 
> The publish step **drops the `NODE_AUTH_TOKEN` environment variable** (and its `secrets.NPM_TOKEN` binding), so publishing no longer passes an npm token through the workflow env block—aligned with provenance/`id-token` setup and the current publish flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e437f05785e224538124d2343239b1c5bcb7ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->