### PR TITLE
fix(ci): remove registry from node-setup collision with OIDC

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,8 +18,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '22'
 
       - run: yarn install
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow tweak with no application runtime changes; low risk aside from validating publish still works on Node 22.
> 
> **Overview**
> Fixes npm publish CI by **removing** `registry-url` from `actions/setup-node`, which was conflicting with **OIDC-based provenance** (`npm publish --provenance` with `id-token: write`). Publishing still authenticates via `NODE_AUTH_TOKEN` / `NPM_TOKEN`.
> 
> Also bumps the publish job **Node version from 20 to 22**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621bf23f10c8eaff903cccfd8f7886d4f7c82ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->